### PR TITLE
Add automated settings menu

### DIFF
--- a/CheeseBot/CheeseBot.csproj
+++ b/CheeseBot/CheeseBot.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <EnablePreviewFeatures>True</EnablePreviewFeatures>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CheeseBot/Commands/Modules/SettingsModules/GeneralSettingsModule.cs
+++ b/CheeseBot/Commands/Modules/SettingsModules/GeneralSettingsModule.cs
@@ -1,3 +1,11 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using CheeseBot.EfCore.Entities;
+using CheeseBot.Extensions;
+using CheeseBot.Settings;
+using CheeseBot.Settings.Formatters;
+using Disqord;
 using Disqord.Bot;
 using Qmmands;
 
@@ -6,6 +14,41 @@ namespace CheeseBot.Commands.Modules
     [Description("Some general server settings")]
     public class GeneralSettingsModule : GuildSettingsModuleBase
     {
+        [Command("settings")]
+        public DiscordCommandResult Settings()
+        {
+            var attributePairs = typeof(GuildSettings).GetProperties()
+                .Select(property => (Property: property, Attribute: property.GetCustomAttributes().OfType<SettingsPropertyAttribute>().SingleOrDefault()))
+                .Where(x => x.Attribute is not null)
+                .OrderBy(x => x.Attribute.Priority);
+            
+            var embed = new LocalEmbed()
+                .WithDefaultColor()
+                .WithTitle("Guild Settings");
+            
+            foreach (var pair in attributePairs)
+            {
+                var type = pair.Attribute.GetType();
+                if (type.IsGenericType)
+                {
+                    var genericType = type.GetGenericArguments().First();
+                    var method = genericType.GetMethod(nameof(ISettingsFormatter.Format));
+                    var formattedValue = method?.Invoke(null, new object[] { CurrentGuildSettings });
+
+                    if (formattedValue is null)
+                        continue;
+
+                    embed.AddField(pair.Attribute.Title, formattedValue);
+                }
+                else
+                {
+                    embed.AddField(pair.Attribute.Title, pair.Property.GetMethod?.Invoke(CurrentGuildSettings, null));
+                }
+            }
+
+            return Response(embed);
+        }
+        
         [Command("permit")]
         [RequireBotOwner]
         public DiscordCommandResult PermitAsync()

--- a/CheeseBot/EfCore/Entities/GuildSettings.cs
+++ b/CheeseBot/EfCore/Entities/GuildSettings.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using CheeseBot.Settings;
+using CheeseBot.Settings.Formatters;
 using Disqord;
 using Disqord.Bot;
 
@@ -12,8 +14,10 @@ namespace CheeseBot.EfCore.Entities
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public Snowflake GuildId { get; set; }
 
+        [SettingsProperty<PermittedFormatter>("Permitted", 0)]
         public bool IsPermitted { get; set; } = false;
         
+        [SettingsProperty<PrefixFormatter>("Prefixes", 1)]
         public List<IPrefix> Prefixes { get; }
 
         public GuildSettings(Snowflake guildId, List<IPrefix> prefixes)

--- a/CheeseBot/Settings/Formatters/ISettingsFormatter.cs
+++ b/CheeseBot/Settings/Formatters/ISettingsFormatter.cs
@@ -1,0 +1,9 @@
+using CheeseBot.EfCore.Entities;
+
+namespace CheeseBot.Settings.Formatters
+{
+    public interface ISettingsFormatter
+    {
+        public static abstract string Format(GuildSettings settings);
+    }
+}

--- a/CheeseBot/Settings/Formatters/PermittedFormatter.cs
+++ b/CheeseBot/Settings/Formatters/PermittedFormatter.cs
@@ -1,0 +1,12 @@
+using CheeseBot.EfCore.Entities;
+
+namespace CheeseBot.Settings.Formatters
+{
+    public class PermittedFormatter : ISettingsFormatter
+    {
+        public static string Format(GuildSettings settings)
+        {
+            return settings.IsPermitted ? true.ToString() : null;
+        }
+    }
+}

--- a/CheeseBot/Settings/Formatters/PrefixFormatter.cs
+++ b/CheeseBot/Settings/Formatters/PrefixFormatter.cs
@@ -1,0 +1,11 @@
+using CheeseBot.EfCore.Entities;
+using CheeseBot.Extensions;
+
+namespace CheeseBot.Settings.Formatters
+{
+    public class PrefixFormatter : ISettingsFormatter
+    {
+        public static string Format(GuildSettings settings)
+            => settings.GetFormattedPrefixList();
+    }
+}

--- a/CheeseBot/Settings/SettingsPropertyAttribute.cs
+++ b/CheeseBot/Settings/SettingsPropertyAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+using CheeseBot.Settings.Formatters;
+
+namespace CheeseBot.Settings
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SettingsPropertyAttribute : Attribute
+    {
+        public string Title { get; }
+        public int Priority { get; }
+
+        public SettingsPropertyAttribute(string title, int priority)
+        {
+            Title = title;
+            Priority = priority;
+        }
+    }
+    
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SettingsPropertyAttribute<TFormatter> : SettingsPropertyAttribute 
+        where TFormatter : ISettingsFormatter
+    {
+        public SettingsPropertyAttribute(string title, int priority)
+            : base (title, priority) { }
+    }
+}


### PR DESCRIPTION
This PR adds a system by which the way a guild setting property is added and displayed on the settings view is determined via an attribute.  The system has the potential to be useful but only if numerous properties shared the display logic or didn't require special display logic.  Otherwise the system will just end up creating more classes and code to manage than simply manually building and displaying each prop in the command itself.

Will leave this PR open until I can decide if this system is worth using